### PR TITLE
Fix proof parser

### DIFF
--- a/src/SAD/ForTheL/Structure.hs
+++ b/src/SAD/ForTheL/Structure.hs
@@ -375,7 +375,7 @@ postMethod = optLL1 None $ short <|> explicit
     explicit = finish $ markupToken proofStart "proof" >> optLL1 Raw method
 
 texPostMethod :: FTL Scheme
-texPostMethod = optLL1 None $ texBegin (markupToken proofStart "proof") >> (short <|> explicit)
+texPostMethod = optLLx None $ texBegin (markupToken proofStart "proof") >> (short <|> explicit)
   where
     short = markupToken proofStart "indeed" >> return Short
     explicit = optLL1 Raw . finish $ markupToken byAnnotation "proof" >> method


### PR DESCRIPTION
There was a problem with if there was a `\begin{` after a theorem,
then `proof` was expected. This was wrong since maybe we want to
write `\begin{theorem}` again after the previous theorem, omitting
the expected proof.