### PR TITLE
Tokenize `\` and `$` away in order to support latex math mode

### DIFF
--- a/examples/chinese.tex.ftl
+++ b/examples/chinese.tex.ftl
@@ -105,6 +105,7 @@ x * (y + z) = (x * y) + (x * z).
 x * 0 = 0 = 0 * x.
 \end{lemma}
 \begin{proof}
+% If you actually compile this file with tex, this section will be very messy.
 Let us show that x * 0 = 0.
 x * 0 .= x * (0 + 0) (by AddZero) .= (x * 0) + (x * 0) (by AMDistr1).
 end.

--- a/examples/powerset.tex
+++ b/examples/powerset.tex
@@ -18,6 +18,12 @@
  \newtheorem{notation}{Notation}[section]
  \numberwithin{equation}{section}
 
+% This is a snippet that lets us use quotation marks in order to write regular text in math mode.
+% Naproche-SAD will ignore all quotation marks.
+\let\ftlquotationmark"
+\catcode`\"=\active
+\def"#1"{\ifmmode\mathrel{\textrm{#1}}\else \ftlquotationmark #1\ftlquotationmark \fi}
+
 \newenvironment{forthel}{}{}
 
 \maketitle 
@@ -29,45 +35,52 @@ This is not parsed by forthel.
 
 \begin{forthel}
 [synonym subset/-s]
+
 [synonym surject/-s]
 
-Let M denote a set.
-Let f denote a function.
+% We add space in between lines in order to let this file produce a reasonable-looking
+% latex pdf.
+Let $M$ denote a set.
 
-Let the value of f at x stand for f[x].
-Let f is defined on M stand for Dom(f) = M.
-Let the domain of f stand for Dom(f).
+Let $f$ denote a function.
+
+Let the value of $f$ at $x$ stand for $f[x]$.
+
+Let $f$ is defined on $M$ stand for $Dom(f) = M$.
+
+Let the domain of $f$ stand for $Dom(f)$.
 
 
 \begin{axiom}
-The value of f at any element of the domain of f is a set.
+The value of $f$ at any element of the domain of $f$ is a set.
 \end{axiom}
 
 \begin{definition}[subset]
-A subset of M is a set N such that every element of N is an element of M.
+A subset of $M$ is a set N such that every element of N is an element of $M$.
 \end{definition}
 
 \begin{definition}
-The powerset of M is the set of subsets of M.
+The powerset of $M$ is the set of subsets of $M$.
 \end{definition}
 
 \begin{definition}
-f surjects onto M iff every element of M is equal to the value of f at some element of the domain of f.
+$f$ surjects onto $M$ iff every element of $M$ is equal to the value of $f$ at some element of the domain of $f$.
 \end{definition}
 
 \begin{proposition}
-No function that is defined on M surjects onto the powerset of M.
+No function that is defined on $M$ surjects onto the powerset of $M$.
 \end{proposition}
 \begin{proof}
 Proof by contradiction.
-Assume the contrary. Take a function f that is defined on M and surjects onto the powerset of M.
-Define N = { x in M | x is not an element of f[x] }.
-Then N is not equal to the value of f at any element of M.
+Assume the contrary. Take a function $f$ that is defined on $M$ and surjects onto the powerset of $M$.
+
+Define $N = \{ x \in M | x "is not an element of" f[x] \}$.
+Then $N$ is not equal to the value of $f$ at any element of $M$.
 Contradiction.
 \end{proof}
 
 \begin{theorem}
-The value of f at any element of the domain of f is a set.
+The value of $f$ at any element of the domain of $f$ is a set.
 \end{theorem}
 
 \end{forthel}

--- a/src/SAD/ForTheL/Base.hs
+++ b/src/SAD/ForTheL/Base.hs
@@ -452,7 +452,7 @@ showVar nm = toLazyText $ represent nm
 -- | Parses '\begin{env}'. Takes a parser for parsing 'env'.
 texBegin :: FTL a -> FTL a
 texBegin envType = do
-  token "\\begin"
+  token "begin"
   symbol "{"
   envType' <- envType
   symbol "}"
@@ -461,7 +461,7 @@ texBegin envType = do
 -- | Parses '\end{env}'. Takes a parser for parsing 'env'.
 texEnd :: FTL () -> FTL ()
 texEnd envType = do
-  token "\\end"
+  token "end"
   symbol "{"
   envType
   symbol "}"


### PR DESCRIPTION
While this obviously isn't the perfect solution, it is a quick and
transparent solution that covers basic usecases.

Moreover, now `"` is also being tokenized away, because it is
intended to be used for telling latex to use text-mode inside a
math-mode environment. This needs a special tex snippet that
remaps `"`. An example on how to use these latex features is in
`examples/powerset.tex`.

Optimally, one would write a tokenizer specifically for math mode,
that then allows the parser to choose how to assign meaning to
specific latex constructs. E.g. one could let fonts specifications
like `\matcal{C}` be part of the variable identifier and let things
like `\frac{x}{y}` be operators. Moreover, there is much more
semantic information that may be potentially attached to latex
constructs. But it would probably be a waste of time to implement
this 'proper' solution with our current tokenizer(consisting of
low-level Text manipulations). One should wait until one gets a
proper tokenizer in order to do this.