### PR TITLE
Expanded vocabulary

### DIFF
--- a/src/SAD/ForTheL/Base.hs
+++ b/src/SAD/ForTheL/Base.hs
@@ -424,7 +424,7 @@ an = tokenOf' ["a", "an"]
 the :: FTL ()
 the = token' "the"
 iff :: FTL ()
-iff = token' "iff" <|> mapM_ token' ["if", "and", "only", "if"]
+iff = token' "iff" <|> mapM_ token' ["if", "and", "only", "if"] <|> mapM_ token' ["when", "and", "only", "when"]
 that :: FTL ()
 that = token' "that"
 standFor :: FTL ()

--- a/src/SAD/ForTheL/Statement.hs
+++ b/src/SAD/ForTheL/Statement.hs
@@ -453,7 +453,7 @@ symbSetNotation = cndSet </> finSet
       pure (\tr -> foldr1 Or $ map (mkEquality tr) ts, h)
     cndSet = braced $ do
       (tag, c, t) <- sepFrom
-      st <- token "|" >> statement;
+      st <- (token "|" <|> token ":") >> statement
       vs <- freeVars t
       vsDecl <- makeDecls $ fvToVarSet vs;
       nm <- if isVar t then pure $ PosVar (varName t) (varPosition t) else hidden

--- a/src/SAD/ForTheL/Structure.hs
+++ b/src/SAD/ForTheL/Structure.hs
@@ -270,7 +270,7 @@ pretype p = p `pretypeBefore` return []
 
 -- low-level header
 hence :: FTL ()
-hence = optLL1 () $ tokenOf' ["then", "hence", "thus", "therefore"]
+hence = optLL1 () $ tokenOf' ["then", "hence", "thus", "therefore", "consequently"]
 letUs :: FTL ()
 letUs = optLL1 () $ (mu "let" >> mu "us") <|> (mu "we" >> mu "can")
   where


### PR DESCRIPTION
Also now `:` or `|` can be used for set notation.