### PR TITLE
Make `\in` a notion pattern

### DIFF
--- a/src/SAD/ForTheL/Base.hs
+++ b/src/SAD/ForTheL/Base.hs
@@ -76,7 +76,9 @@ initFS = FState
       ([Word ["class","classes"], Nm], mkClass . head),
       ([Word ["element", "elements"], Nm, Word ["of"], Vr], \(x:m:_) -> mkElem x m),
       ([Word ["object", "objects"], Nm], mkObj . head)]
-    primSymbNotions = [ ([Symbol "=", Vr], mkTrm EqualityId TermEquality) ]
+    primSymbNotions = [
+      ([Symbol "=", Vr], mkTrm EqualityId TermEquality),
+      ([Symbol "\\in", Vr], \(x:m:_) -> mkElem x m) ]
     primInfixPredicates = [
       ([Symbol "="], mkTrm EqualityId TermEquality),
       ([Symbol "!", Symbol "="], Not . mkTrm EqualityId TermEquality),


### PR DESCRIPTION
This is so `\in` works in quantified notions, for example when
writing `For all $y \in x$ $y = y$`.