### PR TITLE
Fix ambiguity error in set notation

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -16,14 +16,12 @@ flags:
   
 
 when:
-  - condition: flag(debug)
-    then:
-      ghc-options:
-        - -fplugin=StackTrace.Plugin
-        - -Weverything
-      dependencies:
-        - haskell-stack-trace-plugin
-    else: {}
+  condition: flag(debug)
+  dependencies:
+  - haskell-stack-trace-plugin
+  ghc-options:
+  - -fplugin=StackTrace.Plugin
+  - -Weverything
 
 dependencies:
 - base >= 4.7 && < 5

--- a/src/SAD/ForTheL/Statement.hs
+++ b/src/SAD/ForTheL/Statement.hs
@@ -471,7 +471,7 @@ symbSetNotation = cndSet </> finSet
       return (Tag Replacement, \tr -> subst tr (posVarName v) $ q f, pVar v, mkClass) 
     setSep = do
       t <- sTerm
-      elementOf
+      token' "in"
       clssTrm <- (Left <$> sTerm) </> (Right <$> symbSetNotation)
       case clssTrm of
         Left s -> pure (id, flip mkElem s, t, \v -> mkClass v `And` (mkSet s `Imp` mkSet v))


### PR DESCRIPTION
Set notation had an ambiguity error, because it didn't know whether to parse the symbol `\in` directly, or whether to treat is as a notion pattern. Now that it is a notion pattern, we don't need to treat `\in` directly, so I changed the code accordingly.

I accidentally also commited a change that made my `package.yaml` actually work. Because for me `stack build` didn't work with the old `package.yaml`.