### PR TITLE
Add a vocabulary of tex variables

### DIFF
--- a/src/SAD/ForTheL/Base.hs
+++ b/src/SAD/ForTheL/Base.hs
@@ -21,7 +21,6 @@ import qualified Data.Set as Set
 import SAD.Data.Formula
 
 import SAD.Parser.Base
-import SAD.Parser.Token
 import SAD.Parser.Combinators
 import SAD.Parser.Primitives
 
@@ -344,19 +343,12 @@ hidden = do
   return (PosVar (VarHidden n) noSourcePos)
 
 -- | Parse the next token as a variable (a sequence of alpha-num chars beginning with an alpha)
--- and return ('x' + the sequence) with the current position. Additionally, we also allow variables
--- to be able to begin with `\` and continue with alphanumeric characters in order to have tex support.
+-- and return ('x' + the sequence) with the current position.
 var :: FTL PosVar
 var = do
   pos <- getPos
-  v <- satisfy isVariable <|> tokenPrim getTexVariable
+  v <- satisfy (\s -> Text.all isAlphaNum s && isAlpha (Text.head s))
   return (PosVar (VarConstant v) pos)
-  where
-    isVariable s = Text.all isAlphaNum s && isAlpha (Text.head s)
-    getTexVariable t = case Text.uncons (showToken t) of
-      Nothing -> Nothing
-      Just ('\\', rest) | Text.all isAlpha rest -> Just ("tex_" <> rest)
-      Just _ -> Nothing
 
 --- pretyped Variables
 

--- a/src/SAD/ForTheL/Base.hs
+++ b/src/SAD/ForTheL/Base.hs
@@ -458,7 +458,6 @@ with = tokenOf' ["with", "of", "having"]
 such :: FTL ()
 such = tokenOf' ["such", "so"]
 
--- `in` or `\in` is used for various set notations
 elementOf :: FTL ()
 elementOf = token' "in" <|> token "\\in"
 

--- a/src/SAD/Parser/Token.hs
+++ b/src/SAD/Parser/Token.hs
@@ -160,8 +160,42 @@ expandTexCmd "exists" pos whiteSpaceBefore = [makeToken "exists" pos whiteSpaceB
 expandTexCmd "mid" pos whiteSpaceBefore = [makeToken "|" pos whiteSpaceBefore]
 expandTexCmd "rightarrow" pos whiteSpaceBefore = makeSymbolTokens ["-",">"] pos whiteSpaceBefore
 expandTexCmd "lambda" pos whiteSpaceBefore = [makeToken "\\" pos whiteSpaceBefore]
--- If this is not a predefined command to be expanded, just leave the backslash.
+
+-- All tokens starting with `\` are treated as symbols by the parser. But there are tex commands,
+-- that we don't want to treat as symbols in our patterns, for example greek letters. Thus we expand this fixed
+-- list of tex commands here so that they don't use `\`. Note that the fact that this is designed this way makes
+-- it conceptually impossible for the user to configure which tex commands are treated as words on the fly.
+
+-- Tex words
+expandTexCmd s pos whiteSpaceBefore | elem (Text.toLower s) texWords = [makeToken ("tex" <> s) pos whiteSpaceBefore]
+-- If this is not a predefined command to be expanded, just leave the backslash so that it gets treated as a symbol.
 expandTexCmd s pos whiteSpaceBefore = [makeToken (Text.cons '\\' s) pos whiteSpaceBefore]
+
+texWords :: [Text]
+texWords = [
+    "alpha"
+  , "beta"
+  , "gamma"
+  , "delta"
+  , "zeta"
+  , "eta"
+  , "theta"
+  , "iota"
+  , "kappa"
+  , "mu"
+  , "nu"
+  , "xi"
+  , "omicron"
+  , "pi"
+  , "rho"
+  , "sigma"
+  , "tau"
+  , "upsilon"
+  , "phi"
+  , "varphi"
+  , "chi"
+  , "psi"
+  , "omega"]
 
 -- This is only used in `expandTexCmd` and used to apply `makeToken` multiple times, while appropriately
 -- advancing the position.


### PR DESCRIPTION
This resolves a series of serious ambiguity issues, where the parser didn't know whether a tex command was supposed to be parsed as a variable or just as part of a pattern.

As of now, precisely the tex commands that are greek letters (lowercase or uppercase) are accepted as variables(by renaming them in the tokenizer). All other tex commands are simply treated as symbols when they are used in patterns.

This means that by design, it is impossible to dynamically redefine whether a tex command is treated as a variable. This is the same phenomenon that doesn't let us redefine primitive logical symbols like `/\`.